### PR TITLE
Renovate config tweaks and parallel tooling sync

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "labels": [
-    "dependencies"
-  ],
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": [
+    "dependencies"
+  ],
+  "extends": [
+    "config:best-practices"
+  ],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      // Check for GitHub Actions updates once a week (Sunday morning),
+      // grouped into a single PR
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "schedule": [
+        "* 0-8 * * 0"
+      ]
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,6 @@ POM_URL=https://github.com/jonapoul/atlas-gradle-plugin
 RELEASE_SIGNING_ENABLED=true
 SONATYPE_AUTOMATIC_RELEASE=true
 SONATYPE_HOST=CENTRAL_PORTAL
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
- Renovate config moved to json5, using `config:best-practices`
- Added a 3 day `minimumReleaseAge`
- GitHub Actions updates grouped into one weekly PR
- Enabled `org.gradle.tooling.parallel` for Gradle 9.4+