### PR TITLE
Fail CI when a test's required command is missing

### DIFF
--- a/atlas-test/src/test/kotlin/atlas/d2/RequiresD2.kt
+++ b/atlas-test/src/test/kotlin/atlas/d2/RequiresD2.kt
@@ -1,11 +1,5 @@
 package atlas.d2
 
 import atlas.test.RequiresCommand
-import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.CLASS
-import kotlin.annotation.AnnotationTarget.FUNCTION
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@RequiresCommand(command = "d2")
-internal annotation class RequiresD2
+@RequiresCommand(command = "d2") internal annotation class RequiresD2

--- a/atlas-test/src/test/kotlin/atlas/graphviz/RequiresGraphviz.kt
+++ b/atlas-test/src/test/kotlin/atlas/graphviz/RequiresGraphviz.kt
@@ -1,11 +1,5 @@
 package atlas.graphviz
 
 import atlas.test.RequiresCommand
-import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.CLASS
-import kotlin.annotation.AnnotationTarget.FUNCTION
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@RequiresCommand(command = "dot")
-internal annotation class RequiresGraphviz
+@RequiresCommand(command = "dot") internal annotation class RequiresGraphviz

--- a/atlas-test/src/test/kotlin/atlas/test/ExecutionConditions.kt
+++ b/atlas-test/src/test/kotlin/atlas/test/ExecutionConditions.kt
@@ -1,32 +1,18 @@
 package atlas.test
 
-import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.CLASS
-import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.test.fail
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@RequiresCommand(command = "ln")
-annotation class RequiresLn
+@RequiresCommand(command = "ln") annotation class RequiresLn
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@RequiresCommand(command = "whereis")
-annotation class RequiresWhereis
+@RequiresCommand(command = "whereis") annotation class RequiresWhereis
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@RequiresCommand(command = "convert")
-annotation class RequiresImageMagick6
+@RequiresCommand(command = "convert") annotation class RequiresImageMagick6
 
-@Target(FUNCTION, CLASS)
-@Retention(RUNTIME)
-@ExtendWith(RequiresCommandExtension::class)
-annotation class RequiresCommand(val command: String)
+@ExtendWith(RequiresCommandExtension::class) annotation class RequiresCommand(val command: String)
 
 internal class RequiresCommandExtension : ExecutionCondition {
   override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
@@ -48,12 +34,19 @@ internal class RequiresCommandExtension : ExecutionCondition {
       )
     } else {
       val reason = "Missing required commands: ${missingCommands.joinToString()}"
-      ConditionEvaluationResult.disabled(reason)
+
+      if (System.getenv("CI").toBoolean()) {
+        fail(reason)
+      } else {
+        System.err.println("WARNING: $reason - skipping test")
+        ConditionEvaluationResult.disabled(reason)
+      }
     }
   }
 
   private fun Annotation.commandOrNull() =
-    annotationClass.java.getAnnotation(RequiresCommand::class.java)?.command
+    (this as? RequiresCommand)?.command
+      ?: annotationClass.java.getAnnotation(RequiresCommand::class.java)?.command
 
   private fun isCommandAvailable(command: String): Boolean =
     try {


### PR DESCRIPTION
Tests annotated with `@RequiresCommand` (via `@RequiresD2`, `@RequiresGraphviz`, etc) silently skipped when the command wasn't on PATH. On CI that meant whole test classes quietly disappearing.

Now it throws when `CI` is set, and warns + skips locally.

Also fixes `@RequiresCommand` being a no-op when applied directly rather than through a marker annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)