### PR TITLE
Chain test assertions

### DIFF
--- a/src/test/kotlin/atlas/MultipleFrameworksTest.kt
+++ b/src/test/kotlin/atlas/MultipleFrameworksTest.kt
@@ -1,9 +1,9 @@
 package atlas
 
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
+import atlas.test.childExists
+import atlas.test.contentContains
 import atlas.test.noTasksFailed
 import atlas.test.runTask
 import atlas.test.scenarios.MultipleFrameworks
@@ -17,15 +17,15 @@ internal class MultipleFrameworksTest : ScenarioTest() {
       val result = runTask("atlasGenerate").build()
       assertThat(result).noTasksFailed()
 
-      // then each framework wrote to its own directory, so nothing was overwritten
-      assertThat(resolve("a/atlas/d2/chart.d2")).exists()
-      assertThat(resolve("a/atlas/graphviz/chart.dot")).exists()
-      assertThat(resolve("a/atlas/mermaid/chart.mmd")).exists()
-
-      // and the shared legends live in the root project
-      assertThat(resolve("atlas/d2/classes.d2")).exists()
-      assertThat(resolve("atlas/graphviz/legend.dot")).exists()
-      assertThat(resolve("atlas/mermaid/legend.md")).exists()
+      // then each framework wrote to its own directory, so nothing was overwritten, and the shared
+      // legends live in the root project
+      assertThat(this)
+        .childExists("a/atlas/d2/chart.d2")
+        .childExists("a/atlas/graphviz/chart.dot")
+        .childExists("a/atlas/mermaid/chart.mmd")
+        .childExists("atlas/d2/classes.d2")
+        .childExists("atlas/graphviz/legend.dot")
+        .childExists("atlas/mermaid/legend.md")
     }
 
   @Test
@@ -35,9 +35,9 @@ internal class MultipleFrameworksTest : ScenarioTest() {
       runTask("atlasGenerate").build()
 
       // then
-      val readme = resolve("a/README.md").readText()
-      assertThat(readme).contains("![chart](atlas/d2/chart.svg)")
-      assertThat(readme).contains("![chart](atlas/graphviz/chart.svg)")
-      assertThat(readme).contains("```mermaid")
+      assertThat(resolve("a/README.md"))
+        .contentContains("![chart](atlas/d2/chart.svg)")
+        .contentContains("![chart](atlas/graphviz/chart.svg)")
+        .contentContains("```mermaid")
     }
 }

--- a/src/test/kotlin/atlas/core/CheckFileDiffTest.kt
+++ b/src/test/kotlin/atlas/core/CheckFileDiffTest.kt
@@ -1,11 +1,12 @@
 package atlas.core
 
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.containsAtLeast
-import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import atlas.test.ScenarioTest
+import atlas.test.contains
+import atlas.test.contentContains
+import atlas.test.doesNotContain
 import atlas.test.runTask
 import atlas.test.scenarios.CheckExplicitlyDisabled
 import atlas.test.scenarios.CheckExplicitlyEnabled
@@ -24,12 +25,11 @@ internal class CheckFileDiffTest : ScenarioTest() {
       // when
       val result = runTask(":a:checkGraphvizChart", extras = listOf("--dry-run")).build()
 
-      // then the chart wasn't written
-      assertThat(result.output).doesNotContain(":a:writeGraphvizChart")
-
-      // but the dummy and check tasks were run
-      assertThat(result.output).contains(":a:writeDummyGraphvizChart")
-      assertThat(result.output).contains(":a:checkGraphvizChart")
+      // then the chart wasn't written but the dummy and check tasks were run
+      assertThat(result.output)
+        .doesNotContain(":a:writeGraphvizChart")
+        .contains(":a:writeDummyGraphvizChart")
+        .contains(":a:checkGraphvizChart")
     }
 
   @Test
@@ -38,12 +38,11 @@ internal class CheckFileDiffTest : ScenarioTest() {
       // when
       val result = runTask(":a:checkD2Chart", extras = listOf("--dry-run")).build()
 
-      // then the chart wasn't written
-      assertThat(result.output).doesNotContain(":a:writeD2Chart")
-
-      // but the dummy and check tasks were run
-      assertThat(result.output).contains(":a:writeDummyD2Chart")
-      assertThat(result.output).contains(":a:checkD2Chart")
+      // then the chart wasn't written but the dummy and check tasks were run
+      assertThat(result.output)
+        .doesNotContain(":a:writeD2Chart")
+        .contains(":a:writeDummyD2Chart")
+        .contains(":a:checkD2Chart")
     }
 
   @Test
@@ -63,9 +62,8 @@ internal class CheckFileDiffTest : ScenarioTest() {
             .trimIndent()
         )
 
-      val report = resolve("build/reports/problems/problems-report.html")
-      assertThat(report.readText())
-        .contains("Run `gradle :a:writeGraphvizChart` to generate the file.")
+      assertThat(resolve("build/reports/problems/problems-report.html"))
+        .contentContains("Run `gradle :a:writeGraphvizChart` to generate the file.")
     }
 
   @Test

--- a/src/test/kotlin/atlas/core/CollateProjectTypesTest.kt
+++ b/src/test/kotlin/atlas/core/CollateProjectTypesTest.kt
@@ -23,13 +23,12 @@ internal class CollateProjectTypesTest : ScenarioTest() {
       // when
       val result = runTask("collateProjectTypes").build()
 
-      // then three dependent tasks were run
-      assertThat(result).taskWasSuccessful(":test-data:writeProjectType")
-      assertThat(result).taskWasSuccessful(":test-domain:writeProjectType")
-      assertThat(result).taskWasSuccessful(":test-ui:writeProjectType")
-
-      // and this one
-      assertThat(result).taskWasSuccessful(":collateProjectTypes")
+      // then three dependent tasks were run, and this one
+      assertThat(result)
+        .taskWasSuccessful(":test-data:writeProjectType")
+        .taskWasSuccessful(":test-domain:writeProjectType")
+        .taskWasSuccessful(":test-ui:writeProjectType")
+        .taskWasSuccessful(":collateProjectTypes")
 
       // and the types were aggregated in the root project's build dir
       assertThat(projectTypes)
@@ -55,14 +54,12 @@ internal class CollateProjectTypesTest : ScenarioTest() {
       // when
       val result = runTask("collateProjectTypes").build()
 
-      // then three dependent tasks were run
+      // then three dependent tasks were run, and this one
       assertThat(result)
         .taskWasSuccessful(":test-data:writeProjectType")
         .taskWasSuccessful(":test-domain:writeProjectType")
         .taskWasSuccessful(":test-ui:writeProjectType")
-
-      // and this one
-      assertThat(result).taskWasSuccessful(":collateProjectTypes")
+        .taskWasSuccessful(":collateProjectTypes")
 
       // and the types were aggregated in the root project's build dir
       assertThat(projectTypes)

--- a/src/test/kotlin/atlas/core/FrameworkConfigTest.kt
+++ b/src/test/kotlin/atlas/core/FrameworkConfigTest.kt
@@ -1,10 +1,10 @@
 package atlas.core
 
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.doesNotContain
 import atlas.test.ScenarioTest
 import atlas.test.buildRunner
+import atlas.test.contains
+import atlas.test.doesNotContain
 import atlas.test.runTask
 import atlas.test.scenarios.MermaidBasic
 import atlas.test.scenarios.NoFrameworksConfigured
@@ -19,20 +19,18 @@ internal class FrameworkConfigTest : ScenarioTest() {
       // when
       val result = buildRunner().withArguments("help").build()
 
-      // then the D2-only and Graphviz-only properties are called out, grouped by framework
+      // then the D2-only and Graphviz-only properties are called out, grouped by framework, but
+      // stroke is understood by Mermaid so it isn't mentioned
       assertThat(result.output)
         .contains(
           "Warning: project type 'Kotlin JVM' sets render3D and shadow, which only D2 uses. " +
             "Configure the d2 { } block to use them, or remove the config."
         )
-      assertThat(result.output)
         .contains(
           "Warning: project type 'Kotlin JVM' sets peripheries, which only Graphviz uses. " +
             "Configure the graphviz { } block to use it, or remove the config."
         )
-
-      // but stroke is understood by Mermaid, so it isn't mentioned
-      assertThat(result.output).doesNotContain("sets stroke")
+        .doesNotContain("sets stroke")
     }
 
   @Test
@@ -79,8 +77,9 @@ internal class FrameworkConfigTest : ScenarioTest() {
       val result = runTask("tasks", extras = listOf("--all")).build()
 
       // then
-      assertThat(result.output).contains("writeMermaidChart")
-      assertThat(result.output).doesNotContain("writeGraphvizChart")
-      assertThat(result.output).doesNotContain("writeD2Chart")
+      assertThat(result.output)
+        .contains("writeMermaidChart")
+        .doesNotContain("writeGraphvizChart")
+        .doesNotContain("writeD2Chart")
     }
 }

--- a/src/test/kotlin/atlas/core/WriteReadmeTest.kt
+++ b/src/test/kotlin/atlas/core/WriteReadmeTest.kt
@@ -1,11 +1,11 @@
 package atlas.core
 
 import assertk.assertThat
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
 import atlas.test.allSuccessful
+import atlas.test.contentEquals
 import atlas.test.doesNotExist
-import atlas.test.equalsDiffed
+import atlas.test.exists
 import atlas.test.runTask
 import atlas.test.scenarios.MermaidBasic
 import atlas.test.scenarios.MermaidWithLinkTypes
@@ -22,10 +22,9 @@ internal class WriteReadmeTest : ScenarioTest() {
       assertThat(result.tasks).allSuccessful()
 
       // then
-      val readme = resolve("a/README.md")
-      assertThat(readme).exists()
-      assertThat(readme.readText())
-        .equalsDiffed(
+      assertThat(resolve("a/README.md"))
+        .exists()
+        .contentEquals(
           """
           # a
 
@@ -52,10 +51,9 @@ internal class WriteReadmeTest : ScenarioTest() {
       assertThat(result.tasks).allSuccessful()
 
       // then
-      val readme = resolve("a/README.md")
-      assertThat(readme).exists()
-      assertThat(readme.readText())
-        .equalsDiffed(
+      assertThat(resolve("a/README.md"))
+        .exists()
+        .contentEquals(
           """
           # a
 
@@ -136,11 +134,11 @@ internal class WriteReadmeTest : ScenarioTest() {
         Some suffix
         """
           .trimIndent()
-      assertThat(readme.readText()).equalsDiffed(expected)
+      assertThat(readme).contentEquals(expected)
 
       // when we run again and force the regeneration
       val result2 = runTask(":a:writeReadme", extras = listOf("--rerun-tasks")).build()
       assertThat(result2).taskHadResult(":a:writeReadme", SUCCESS)
-      assertThat(readme.readText()).equalsDiffed(expected)
+      assertThat(readme).contentEquals(expected)
     }
 }

--- a/src/test/kotlin/atlas/d2/tasks/ExecD2Test.kt
+++ b/src/test/kotlin/atlas/d2/tasks/ExecD2Test.kt
@@ -1,11 +1,11 @@
 package atlas.d2.tasks
 
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.exists
 import atlas.d2.RequiresD2
 import atlas.test.ScenarioTest
 import atlas.test.allSuccessful
+import atlas.test.childExists
+import atlas.test.contains
 import atlas.test.runTask
 import atlas.test.scenarios.D2Basic
 import atlas.test.scenarios.D2CustomLayoutEngine
@@ -68,9 +68,10 @@ internal class ExecD2Test : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      assertThat(resolve("a/atlas/d2/chart.svg")).exists()
-      assertThat(resolve("b/atlas/d2/chart.svg")).exists()
-      assertThat(resolve("c/atlas/d2/chart.svg")).exists()
+      assertThat(this)
+        .childExists("a/atlas/d2/chart.svg")
+        .childExists("b/atlas/d2/chart.svg")
+        .childExists("c/atlas/d2/chart.svg")
     }
 
   @Test

--- a/src/test/kotlin/atlas/d2/tasks/SvgToPngTest.kt
+++ b/src/test/kotlin/atlas/d2/tasks/SvgToPngTest.kt
@@ -1,16 +1,17 @@
 package atlas.d2.tasks
 
 import assertk.assertThat
-import assertk.assertions.exists
 import atlas.test.D2Scenario
 import atlas.test.RequiresImageMagick6
 import atlas.test.ScenarioTest
 import atlas.test.allTasksSuccessful
-import atlas.test.doesNotExist
+import atlas.test.childDoesNotExist
+import atlas.test.childExists
 import atlas.test.noTasksFailed
 import atlas.test.runTask
 import atlas.test.scenarios.D2Basic
 import atlas.test.taskHadResult
+import atlas.test.tasksHadResult
 import java.lang.ProcessBuilder.Redirect.PIPE
 import kotlin.test.Test
 import org.gradle.testkit.runner.TaskOutcome.SKIPPED
@@ -33,8 +34,7 @@ internal class SvgToPngTest : ScenarioTest() {
 
       // then both SVG and PNG were output
       assertThat(result).allTasksSuccessful()
-      assertThat(resolve("a/atlas/d2/chart.svg")).exists()
-      assertThat(resolve("a/atlas/d2/chart.png")).exists()
+      assertThat(this).childExists("a/atlas/d2/chart.svg").childExists("a/atlas/d2/chart.png")
 
       // result is cached
       assertThat(runTask("svgToPng").build()).taskHadResult(":a:svgToPng", UP_TO_DATE)
@@ -47,18 +47,13 @@ internal class SvgToPngTest : ScenarioTest() {
       val result = runTask("atlasGenerate").build()
 
       // then
-      assertThat(resolve("a/atlas/d2/chart.svg")).exists()
-      assertThat(resolve("a/atlas/d2/chart.png")).doesNotExist()
+      assertThat(this).childExists("a/atlas/d2/chart.svg").childDoesNotExist("a/atlas/d2/chart.png")
 
       // and the charts were generated, but the PNGs weren't
       assertThat(result)
         .noTasksFailed()
-        .taskHadResult(":a:execD2Chart", SUCCESS)
-        .taskHadResult(":b:execD2Chart", SUCCESS)
-        .taskHadResult(":c:execD2Chart", SUCCESS)
-        .taskHadResult(":a:svgToPng", SKIPPED)
-        .taskHadResult(":b:svgToPng", SKIPPED)
-        .taskHadResult(":c:svgToPng", SKIPPED)
+        .tasksHadResult(SUCCESS, ":a:execD2Chart", ":b:execD2Chart", ":c:execD2Chart")
+        .tasksHadResult(SKIPPED, ":a:svgToPng", ":b:svgToPng", ":c:svgToPng")
     }
 
   @Test
@@ -69,18 +64,13 @@ internal class SvgToPngTest : ScenarioTest() {
       val result = runTask("atlasGenerate").build()
 
       // then
-      assertThat(resolve("a/atlas/d2/chart.txt")).exists()
-      assertThat(resolve("a/atlas/d2/chart.png")).doesNotExist()
+      assertThat(this).childExists("a/atlas/d2/chart.txt").childDoesNotExist("a/atlas/d2/chart.png")
 
       // and the charts were generated, but the PNGs weren't
       assertThat(result)
         .noTasksFailed()
-        .taskHadResult(":a:execD2Chart", SUCCESS)
-        .taskHadResult(":b:execD2Chart", SUCCESS)
-        .taskHadResult(":c:execD2Chart", SUCCESS)
-        .taskHadResult(":a:svgToPng", SKIPPED)
-        .taskHadResult(":b:svgToPng", SKIPPED)
-        .taskHadResult(":c:svgToPng", SKIPPED)
+        .tasksHadResult(SUCCESS, ":a:execD2Chart", ":b:execD2Chart", ":c:execD2Chart")
+        .tasksHadResult(SKIPPED, ":a:svgToPng", ":b:svgToPng", ":c:svgToPng")
     }
 
   private fun assumeConverterIsInstalled(converter: SvgToPng.Converter) {

--- a/src/test/kotlin/atlas/d2/tasks/WriteD2ChartTest.kt
+++ b/src/test/kotlin/atlas/d2/tasks/WriteD2ChartTest.kt
@@ -1,11 +1,12 @@
 package atlas.d2.tasks
 
 import assertk.assertThat
-import assertk.assertions.exists
 import atlas.d2.RequiresD2
 import atlas.test.ScenarioTest
 import atlas.test.allTasksSuccessful
+import atlas.test.childExists
 import atlas.test.contentEquals
+import atlas.test.exists
 import atlas.test.noTasksFailed
 import atlas.test.runTask
 import atlas.test.scenarios.D2Basic
@@ -87,11 +88,10 @@ internal class WriteD2ChartTest : ScenarioTest() {
       // then
       assertThat(result).noTasksFailed()
 
-      // and the file was generated
-      val chartFile = resolve("path/to/my/project/atlas/d2/chart.d2")
-      assertThat(chartFile.exists())
-      assertThat(resolve("atlas/d2/classes.d2")).exists()
-      assertThat(chartFile)
+      // and the files were generated
+      assertThat(this).childExists("atlas/d2/classes.d2")
+      assertThat(resolve("path/to/my/project/atlas/d2/chart.d2"))
+        .exists()
         .contentEquals(
           """
           ...@../../../../../../atlas/d2/classes.d2

--- a/src/test/kotlin/atlas/d2/tasks/WriteD2ClassesTest.kt
+++ b/src/test/kotlin/atlas/d2/tasks/WriteD2ClassesTest.kt
@@ -2,7 +2,7 @@ package atlas.d2.tasks
 
 import assertk.assertThat
 import atlas.test.ScenarioTest
-import atlas.test.equalsDiffed
+import atlas.test.contentEquals
 import atlas.test.runTask
 import atlas.test.scenarios.D2AllProjectTypes
 import atlas.test.taskWasSuccessful
@@ -19,8 +19,8 @@ internal class WriteD2ClassesTest : ScenarioTest() {
       assertThat(result).taskWasSuccessful(":writeD2Classes")
 
       // and the file was generated
-      assertThat(resolve("atlas/d2/classes.d2").readText())
-        .equalsDiffed(
+      assertThat(resolve("atlas/d2/classes.d2"))
+        .contentEquals(
           """
           classes: {
             project-AndroidApp {

--- a/src/test/kotlin/atlas/graphviz/tasks/ExecGraphvizTest.kt
+++ b/src/test/kotlin/atlas/graphviz/tasks/ExecGraphvizTest.kt
@@ -1,24 +1,25 @@
 package atlas.graphviz.tasks
 
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.containsMatch
-import assertk.assertions.exists
 import assertk.assertions.isEqualTo
 import atlas.graphviz.RequiresGraphviz
 import atlas.test.RequiresLn
 import atlas.test.RequiresWhereis
 import atlas.test.ScenarioTest
 import atlas.test.allSuccessful
-import atlas.test.doesNotExist
+import atlas.test.childDoesNotExist
+import atlas.test.childExists
+import atlas.test.contains
+import atlas.test.exists
 import atlas.test.noTasksFailed
 import atlas.test.runTask
 import atlas.test.scenarios.GraphVizBasicWithPngOutput
 import atlas.test.scenarios.GraphVizCustomDotExecutable
 import atlas.test.scenarios.GraphVizCustomLayoutEngine
 import atlas.test.scenarios.GraphvizBasic
+import atlas.test.tasksWereSuccessful
 import kotlin.test.Test
-import org.gradle.testkit.runner.TaskOutcome
 
 internal class ExecGraphvizTest : ScenarioTest() {
   @Test
@@ -71,19 +72,18 @@ internal class ExecGraphvizTest : ScenarioTest() {
       val result = runTask("atlasGenerate").build()
 
       // then PNG, SVG and EPS tasks were run for each subproject
-      listOf(
+      assertThat(result)
+        .tasksWereSuccessful(
           ":a:execGraphvizChart",
           ":b:execGraphvizChart",
           ":c:execGraphvizChart",
         )
-        .forEach { t ->
-          assertThat(result.task(t)?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        }
 
       // and the relevant files exist
-      for (subproject in listOf("a", "b", "c")) {
-        assertThat(resolve("$subproject/atlas/graphviz/chart.png")).exists()
-      }
+      assertThat(this)
+        .childExists("a/atlas/graphviz/chart.png")
+        .childExists("b/atlas/graphviz/chart.png")
+        .childExists("c/atlas/graphviz/chart.png")
     }
 
   @Test
@@ -128,7 +128,7 @@ internal class ExecGraphvizTest : ScenarioTest() {
   fun `Fail with nonexistent custom path to dot command`() =
     runScenario(GraphVizCustomDotExecutable) {
       // Given we've made a symbolic link to a dot executable which doesn't exist
-      assertThat(resolve("path/to/custom/dot")).doesNotExist()
+      assertThat(this).childDoesNotExist("path/to/custom/dot")
 
       // when
       val result = runTask("atlasGenerate").buildAndFail()

--- a/src/test/kotlin/atlas/graphviz/tasks/WriteGraphvizChartTest.kt
+++ b/src/test/kotlin/atlas/graphviz/tasks/WriteGraphvizChartTest.kt
@@ -1,9 +1,9 @@
 package atlas.graphviz.tasks
 
 import assertk.assertThat
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
-import atlas.test.equalsDiffed
+import atlas.test.contentEquals
+import atlas.test.exists
 import atlas.test.runTask
 import atlas.test.scenarios.GraphVizChartCustomConfig
 import atlas.test.scenarios.GraphVizChartWithCustomLinkTypes
@@ -22,8 +22,8 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       runTask("writeGraphvizChart").build()
 
       // then
-      assertThat(resolve("app/atlas/graphviz/chart.dot").readText())
-        .equalsDiffed(
+      assertThat(resolve("app/atlas/graphviz/chart.dot"))
+        .contentEquals(
           """
           digraph {
             ":app"
@@ -62,8 +62,8 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       val dotFileC = resolve("c/atlas/graphviz/chart.dot")
 
       // and contain expected contents, with projects in declaration order
-      assertThat(dotFileA.readText())
-        .equalsDiffed(
+      assertThat(dotFileA)
+        .contentEquals(
           """
           digraph {
             ":a" [fillcolor="mediumorchid"]
@@ -76,8 +76,8 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
             .trimIndent()
         )
 
-      assertThat(dotFileB.readText())
-        .equalsDiffed(
+      assertThat(dotFileB)
+        .contentEquals(
           """
           digraph {
             ":b" [fillcolor="orange"]
@@ -85,8 +85,8 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
           """
             .trimIndent()
         )
-      assertThat(dotFileC.readText())
-        .equalsDiffed(
+      assertThat(dotFileC)
+        .contentEquals(
           """
           digraph {
             ":c" [fillcolor="orange"]
@@ -102,13 +102,10 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       // when
       runTask("writeGraphvizChart").build()
 
-      // then the file was generated
-      val dotFile = resolve("a/atlas/graphviz/chart.dot")
-      assertThat(dotFile).exists()
-
-      // and contains expected contents, with projects in alphabetical order
-      assertThat(dotFile.readText())
-        .equalsDiffed(
+      // then the file was generated, with projects in alphabetical order
+      assertThat(resolve("a/atlas/graphviz/chart.dot"))
+        .exists()
+        .contentEquals(
           """
           digraph {
             edge [arrowhead="halfopen",arrowtail="open"]
@@ -131,13 +128,10 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       // when
       runTask("writeGraphvizChart").build()
 
-      // then the file was generated
-      val dotFile = resolve("a/atlas/graphviz/chart.dot")
-      assertThat(dotFile).exists()
-
-      // and contains expected contents, with projects in alphabetical order
-      assertThat(dotFile.readText())
-        .equalsDiffed(
+      // then the file was generated, with projects in alphabetical order
+      assertThat(resolve("a/atlas/graphviz/chart.dot"))
+        .exists()
+        .contentEquals(
           """
           digraph {
             graph [layout="neato"]
@@ -158,13 +152,10 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       // when
       runTask("writeGraphvizChart").build()
 
-      // then the file was generated
-      val dotFile = resolve("a/atlas/graphviz/chart.dot")
-      assertThat(dotFile).exists()
-
-      // and contains expected contents, colons removed from project prefixes and "b" -> "B"
-      assertThat(dotFile.readText())
-        .equalsDiffed(
+      // then the file was generated, with colons removed from project prefixes and "b" -> "B"
+      assertThat(resolve("a/atlas/graphviz/chart.dot"))
+        .exists()
+        .contentEquals(
           """
           digraph {
             "B" [fillcolor="orange"]
@@ -184,13 +175,10 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       // when
       runTask("writeGraphvizChart").build()
 
-      // then the file was generated
-      val dotFile = resolve("a/atlas/graphviz/chart.dot")
-      assertThat(dotFile).exists()
-
-      // and contains expected link styles
-      assertThat(dotFile.readText())
-        .equalsDiffed(
+      // then the file was generated, with the expected link styles
+      assertThat(resolve("a/atlas/graphviz/chart.dot"))
+        .exists()
+        .contentEquals(
           """
           digraph {
             ":a" [fillcolor="mediumorchid"]
@@ -212,13 +200,10 @@ internal class WriteGraphvizChartTest : ScenarioTest() {
       // when
       runTask("writeGraphvizChart").build()
 
-      // then the file was generated
-      val dotFile = resolve("app/atlas/graphviz/chart.dot")
-      assertThat(dotFile).exists()
-
-      // and contains expected link styles
-      assertThat(dotFile.readText())
-        .equalsDiffed(
+      // then the file was generated, with the expected link styles
+      assertThat(resolve("app/atlas/graphviz/chart.dot"))
+        .exists()
+        .contentEquals(
           """
           digraph {
             ":app" [fillcolor="mediumorchid"]

--- a/src/test/kotlin/atlas/graphviz/tasks/WriteGraphvizLegendTest.kt
+++ b/src/test/kotlin/atlas/graphviz/tasks/WriteGraphvizLegendTest.kt
@@ -1,10 +1,10 @@
 package atlas.graphviz.tasks
 
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
+import atlas.test.contentContains
 import atlas.test.contentEquals
+import atlas.test.exists
 import atlas.test.runTask
 import atlas.test.scenarios.GraphVizWithLinkTypes
 import atlas.test.scenarios.GraphvizBasic
@@ -17,13 +17,10 @@ internal class WriteGraphvizLegendTest : ScenarioTest() {
       // when
       runTask("writeGraphvizLegend").build()
 
-      // then the file was generated
-      val legendFile = resolve("atlas/graphviz/legend.dot")
-      assertThat(legendFile).exists()
-
-      // and contains expected contents, with projects in declaration order
-      assertThat(legendFile.readText())
-        .contains(
+      // then the file was generated, with projects in declaration order
+      assertThat(resolve("atlas/graphviz/legend.dot"))
+        .exists()
+        .contentContains(
           """
           digraph {
             node [shape="plaintext"]
@@ -47,12 +44,9 @@ internal class WriteGraphvizLegendTest : ScenarioTest() {
       // when
       runTask("writeGraphvizLegend").build()
 
-      // then the file was generated
-      val legendFile = resolve("atlas/graphviz/legend.dot")
-      assertThat(legendFile).exists()
-
-      // and contains expected contents, overriding build script
-      assertThat(legendFile)
+      // then the file was generated, overriding build script
+      assertThat(resolve("atlas/graphviz/legend.dot"))
+        .exists()
         .contentEquals(
           """
           digraph {

--- a/src/test/kotlin/atlas/mermaid/WriteMarkdownLegendTest.kt
+++ b/src/test/kotlin/atlas/mermaid/WriteMarkdownLegendTest.kt
@@ -1,11 +1,11 @@
 package atlas.mermaid
 
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
 import atlas.test.allSuccessful
-import atlas.test.equalsDiffed
+import atlas.test.contentContains
+import atlas.test.contentEquals
+import atlas.test.exists
 import atlas.test.runTask
 import atlas.test.scenarios.MermaidWithLinkTypes
 import atlas.test.scenarios.MermaidWithProjectTypes
@@ -20,10 +20,9 @@ internal class WriteMarkdownLegendTest : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      val legend = resolve("atlas/mermaid/legend.md")
-      assertThat(legend).exists()
-      assertThat(legend.readText())
-        .contains(
+      assertThat(resolve("atlas/mermaid/legend.md"))
+        .exists()
+        .contentContains(
           """
           | Project Types | Color |
           |:--:|:--:|
@@ -42,10 +41,9 @@ internal class WriteMarkdownLegendTest : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      val legend = resolve("atlas/mermaid/legend.md")
-      assertThat(legend).exists()
-      assertThat(legend.readText())
-        .equalsDiffed(
+      assertThat(resolve("atlas/mermaid/legend.md"))
+        .exists()
+        .contentEquals(
           """
           | Link Types | Style |
           |:--:|:--:|

--- a/src/test/kotlin/atlas/mermaid/WriteMermaidChartTest.kt
+++ b/src/test/kotlin/atlas/mermaid/WriteMermaidChartTest.kt
@@ -1,10 +1,10 @@
 package atlas.mermaid
 
 import assertk.assertThat
-import assertk.assertions.exists
 import atlas.test.ScenarioTest
 import atlas.test.allSuccessful
-import atlas.test.equalsDiffed
+import atlas.test.contentEquals
+import atlas.test.exists
 import atlas.test.runTask
 import atlas.test.scenarios.MermaidWithGroupsNested
 import atlas.test.scenarios.MermaidWithGroupsNotNested
@@ -20,10 +20,9 @@ internal class WriteMermaidChartTest : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      val chart = resolve("a/atlas/mermaid/chart.mmd")
-      assertThat(chart).exists()
-      assertThat(chart.readText())
-        .equalsDiffed(
+      assertThat(resolve("a/atlas/mermaid/chart.mmd"))
+        .exists()
+        .contentEquals(
           """
           graph TD
             _a[":a"]
@@ -44,10 +43,9 @@ internal class WriteMermaidChartTest : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      val chart = resolve("a/atlas/mermaid/chart.mmd")
-      assertThat(chart).exists()
-      assertThat(chart.readText())
-        .equalsDiffed(
+      assertThat(resolve("a/atlas/mermaid/chart.mmd"))
+        .exists()
+        .contentEquals(
           """
           graph TD
             _a[":a"]
@@ -68,10 +66,9 @@ internal class WriteMermaidChartTest : ScenarioTest() {
 
       // then
       assertThat(result.tasks).allSuccessful()
-      val chart = resolve("a/atlas/mermaid/chart.mmd")
-      assertThat(chart).exists()
-      assertThat(chart.readText())
-        .equalsDiffed(
+      assertThat(resolve("a/atlas/mermaid/chart.mmd"))
+        .exists()
+        .contentEquals(
           """
           graph TD
             _a[":a"]

--- a/src/test/kotlin/atlas/test/Assertions.kt
+++ b/src/test/kotlin/atlas/test/Assertions.kt
@@ -1,6 +1,10 @@
 package atlas.test
 
 import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.contains as assertkContains
+import assertk.assertions.doesNotContain as assertkDoesNotContain
+import assertk.assertions.exists as assertkExists
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import assertk.assertions.support.expected
@@ -48,6 +52,14 @@ internal fun Assert<BuildResult>.taskHadResult(
   }
 }
 
+internal fun Assert<BuildResult>.tasksHadResult(
+  expected: TaskOutcome,
+  vararg names: String,
+): Assert<BuildResult> = names.fold(this) { assert, name -> assert.taskHadResult(name, expected) }
+
+internal fun Assert<BuildResult>.tasksWereSuccessful(vararg names: String): Assert<BuildResult> =
+  tasksHadResult(SUCCESS, *names)
+
 internal fun Assert<File>.contentEquals(expected: String): Assert<File> = transform { file ->
   val contents = file.readText().removeSuffix("\n")
   if (contents == expected) {
@@ -59,6 +71,16 @@ internal fun Assert<File>.contentEquals(expected: String): Assert<File> = transf
   }
 }
 
+internal fun Assert<File>.contentContains(expected: String): Assert<File> = transform { file ->
+  assertThat(file.readText()).contains(expected)
+  file
+}
+
+internal fun Assert<File>.exists(): Assert<File> = transform { file ->
+  assertThat(file).assertkExists()
+  file
+}
+
 // Copied from assertk repo but they haven't published in ages
 // https://github.com/assertk-org/assertk/blob/main/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
 internal fun Assert<File>.doesNotExist(): Assert<File> = transform { actual ->
@@ -67,6 +89,16 @@ internal fun Assert<File>.doesNotExist(): Assert<File> = transform { actual ->
   } else {
     expected("$actual not to exist")
   }
+}
+
+internal fun Assert<File>.childExists(path: String): Assert<File> = transform { dir ->
+  assertThat(dir.resolve(path)).exists()
+  dir
+}
+
+internal fun Assert<File>.childDoesNotExist(path: String): Assert<File> = transform { dir ->
+  assertThat(dir.resolve(path)).doesNotExist()
+  dir
 }
 
 internal fun Assert<String>.equalsDiffed(expected: String): Assert<String> = transform { actual ->
@@ -83,9 +115,11 @@ internal fun Assert<String>.equalsDiffed(expected: String): Assert<String> = tra
 internal fun <T> Assert<Set<T>>.isEqualToSet(vararg expected: T) = isEqualTo(expected.toSet())
 
 internal fun Assert<String>.contains(expected: String): Assert<String> = transform { actual ->
-  if (actual.contains(expected)) {
-    actual
-  } else {
-    expected("string to contain '$expected' - actual = $actual")
-  }
+  assertThat(actual).assertkContains(expected)
+  actual
+}
+
+internal fun Assert<String>.doesNotContain(expected: String): Assert<String> = transform { actual ->
+  assertThat(actual).assertkDoesNotContain(expected)
+  actual
 }


### PR DESCRIPTION
Adds chainable variants of the assertions we repeat, so tests assert once per receiver instead of repeating `assertThat` with the same argument.

New helpers in `Assertions.kt`:
- `Assert<File>.exists()`, `contentContains()`
- `Assert<File>.childExists()` / `childDoesNotExist()` for asserting about files under a project dir
- `Assert<BuildResult>.tasksHadResult()` / `tasksWereSuccessful()`

Also swaps `assertThat(file.readText()).equalsDiffed(...)` for `assertThat(file).contentEquals(...)` throughout, since it's the same check and chains off `exists()`. `equalsDiffed` now only covers the writer unit tests, which really do assert on strings.