### PR TITLE
Fix publish?

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -49,4 +49,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_IN_MEMORY_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
-        run: ./gradlew publishToMavenCentral -x dokkaGeneratePublicationHtml --no-configuration-cache
+        run: ./gradlew publishToMavenCentral -x dokkaGeneratePublicationHtml

--- a/.run/dokkaGeneratePublicationHtml.run.xml
+++ b/.run/dokkaGeneratePublicationHtml.run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--rerun-tasks --no-build-cache --no-configuration-cache" />
+      <option name="scriptParameters" value="--rerun-tasks --no-build-cache" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ To run a specific test method:
 ### Documentation
 This task will take a while, so don't run unless really necessary:
 ```bash
-./gradlew dokkaGeneratePublicationHtml --rerun-tasks --no-build-cache --no-configuration-cache       # Generate API docs to docs/api/
+./gradlew dokkaGeneratePublicationHtml --rerun-tasks --no-build-cache  # Generate API docs to docs/api/
 ```
 
 ### Plugin Development


### PR DESCRIPTION
From https://github.com/jonapoul/atlas-gradle-plugin/actions/runs/31206329213/job/92958202123:
```
FAILURE: Build failed with an exception.

* What went wrong:
Configuration Cache cannot be disabled when Isolated Projects is enabled.
```